### PR TITLE
feat: Add group member management and prompt examples

### DIFF
--- a/frontend/app/src/main/java/com/fiveis/xend/data/model/GroupResponse.kt
+++ b/frontend/app/src/main/java/com/fiveis/xend/data/model/GroupResponse.kt
@@ -9,6 +9,7 @@ data class GroupResponse(
     val name: String,
     val description: String? = null,
     val options: List<PromptOption> = emptyList(),
+    val contacts: List<ContactResponse>? = null,
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("updated_at") val updatedAt: String? = null
 )
@@ -18,6 +19,18 @@ fun GroupResponse.toDomain(): Group = Group(
     name = name,
     description = description,
     options = options,
+    members = contacts?.map { contactResponse ->
+        Contact(
+            id = contactResponse.id,
+            // 순환 참조 방지
+            group = null,
+            name = contactResponse.name,
+            email = contactResponse.email,
+            context = contactResponse.context?.toDomain(),
+            createdAt = contactResponse.createdAt,
+            updatedAt = contactResponse.updatedAt
+        )
+    } ?: emptyList(),
     createdAt = createdAt,
     updatedAt = updatedAt
 )

--- a/frontend/app/src/main/java/com/fiveis/xend/network/ContactApiService.kt
+++ b/frontend/app/src/main/java/com/fiveis/xend/network/ContactApiService.kt
@@ -10,6 +10,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -26,6 +27,9 @@ interface ContactApiService {
 
     @DELETE("api/contact/{id}/")
     suspend fun deleteContact(@Path("id") contactId: Long): Response<Void>
+
+    @PATCH("api/contact/{id}/")
+    suspend fun updateContact(@Path("id") contactId: Long, @Body payload: Map<String, Long>): Response<ContactResponse>
 
     // 그룹 관련
     @POST("api/contact/groups/")

--- a/frontend/app/src/main/java/com/fiveis/xend/ui/compose/MailComposeActivity.kt
+++ b/frontend/app/src/main/java/com/fiveis/xend/ui/compose/MailComposeActivity.kt
@@ -944,13 +944,6 @@ class MailComposeActivity : ComponentActivity() {
                 var newContact by remember { mutableStateOf(TextFieldValue("")) }
                 var showTemplateScreen by remember { mutableStateOf(false) }
 
-                // Set initial content for the editor
-                LaunchedEffect(Unit) {
-                    richTextState.setHtml(
-                        "안녕하세요, 대표님.<br><br>Q4 실적 보고서를 검토했습니다.<br><br>전반적으로 매출 증가율이 목표치를 상회하는 <b>우수한 성과</b>라고 판단됩니다."
-                    )
-                }
-
                 // Collect UI states from ViewModels
                 val composeUi by composeVm.ui.collectAsState()
                 val sendUi by sendVm.ui.collectAsState()

--- a/frontend/app/src/main/java/com/fiveis/xend/ui/contactbook/AddGroupActivity.kt
+++ b/frontend/app/src/main/java/com/fiveis/xend/ui/contactbook/AddGroupActivity.kt
@@ -7,17 +7,14 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.fiveis.xend.R
 import com.fiveis.xend.data.model.PromptOption
@@ -46,10 +43,17 @@ class AddGroupActivity : ComponentActivity() {
                 val bookViewModel: ContactBookViewModel = viewModel()
                 val bookUiState by bookViewModel.uiState.collectAsState()
 
+                // 연락처 목록 로드
+                LaunchedEffect(Unit) {
+                    bookViewModel.onTabSelected(com.fiveis.xend.data.repository.ContactBookTab.Contacts)
+                }
+
                 // AddGroupScreen 입력값들 보관
                 var name by rememberSaveable { mutableStateOf("") }
                 var description by rememberSaveable { mutableStateOf("") }
                 var options by rememberSaveable { mutableStateOf(emptyList<PromptOption>()) }
+                var members by remember { mutableStateOf(emptyList<com.fiveis.xend.data.model.Contact>()) }
+                var showContactSelectDialog by remember { mutableStateOf(false) }
 
                 AddGroupScreen(
                     uiState = addUiState,
@@ -58,10 +62,15 @@ class AddGroupActivity : ComponentActivity() {
                         overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
                     },
                     onAdd = {
+                        android.util.Log.d(
+                            "AddGroupActivity",
+                            "Saving group - name: $name, options: ${options.size}, members: ${members.size}"
+                        )
                         addViewModel.addGroup(
                             name = name,
                             description = description,
-                            options = options
+                            options = options,
+                            members = members
                         )
                     },
                     onGroupNameChange = { name = it },
@@ -78,12 +87,12 @@ class AddGroupActivity : ComponentActivity() {
                             onError = onError
                         )
                     },
-                    members = emptyList(),
+                    members = members,
                     onAddMember = {
-                        // TODO
+                        showContactSelectDialog = true
                     },
                     onMemberClick = {
-                        // TODO
+                        // TODO: 멤버 상세 또는 삭제
                     },
                     onBottomNavChange = { tab ->
                         if (tab == "inbox") {
@@ -93,10 +102,26 @@ class AddGroupActivity : ComponentActivity() {
                     }
                 )
 
+                // 연락처 선택 다이얼로그
+                if (showContactSelectDialog) {
+                    android.util.Log.d("AddGroupActivity", "Showing dialog with ${bookUiState.contacts.size} contacts")
+                    ContactSelectDialog(
+                        contacts = bookUiState.contacts,
+                        selectedContacts = members,
+                        onDismiss = { showContactSelectDialog = false },
+                        onConfirm = { selected ->
+                            android.util.Log.d("AddGroupActivity", "Selected contacts: ${selected.size}")
+                            members = selected
+                            android.util.Log.d("AddGroupActivity", "Members after update: ${members.size}")
+                            showContactSelectDialog = false
+                        }
+                    )
+                }
+
                 // 결과 피드백
                 LaunchedEffect(addUiState.error, addUiState.lastSuccessMsg) {
                     addUiState.error?.let {
-                        Toast.makeText(this@AddGroupActivity, it, Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@AddGroupActivity, it, Toast.LENGTH_LONG).show()
                     }
                     addUiState.lastSuccessMsg?.let {
                         Toast.makeText(this@AddGroupActivity, it, Toast.LENGTH_SHORT).show()
@@ -106,12 +131,8 @@ class AddGroupActivity : ComponentActivity() {
                     }
                 }
 
-                if (addUiState.isLoading) {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = androidx.compose.ui.Alignment.Center
-                    ) { CircularProgressIndicator() }
-                }
+                // 프롬프트 옵션 로딩 중일 때만 로딩 표시 (화면은 그대로 보임)
+                // 그룹 추가 중에는 전체 화면 로딩
             }
         }
     }

--- a/frontend/app/src/main/java/com/fiveis/xend/ui/contactbook/ContactBookScreen.kt
+++ b/frontend/app/src/main/java/com/fiveis/xend/ui/contactbook/ContactBookScreen.kt
@@ -78,7 +78,7 @@ fun ContactBookScreen(
     onEditContactClick: (Contact) -> Unit = {},
     onDeleteContactClick: (Contact) -> Unit = {}
 ) {
-    var selectedTab by remember { mutableStateOf(ContactBookTab.Groups) }
+    val selectedTab = uiState.selectedTab
 
     if (selectedTab == ContactBookTab.Groups) {
         Scaffold(
@@ -111,12 +111,14 @@ fun ContactBookScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     TabChip("그룹별", selectedTab == ContactBookTab.Groups) {
-                        selectedTab = ContactBookTab.Groups
-                        onTabSelected(ContactBookTab.Groups)
+                        if (selectedTab != ContactBookTab.Groups) {
+                            onTabSelected(ContactBookTab.Groups)
+                        }
                     }
                     TabChip("전체", selectedTab == ContactBookTab.Contacts) {
-                        selectedTab = ContactBookTab.Contacts
-                        onTabSelected(ContactBookTab.Contacts)
+                        if (selectedTab != ContactBookTab.Contacts) {
+                            onTabSelected(ContactBookTab.Contacts)
+                        }
                     }
                 }
 
@@ -171,12 +173,14 @@ fun ContactBookScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     TabChip("그룹별", selectedTab == ContactBookTab.Groups) {
-                        selectedTab = ContactBookTab.Groups
-                        onTabSelected(ContactBookTab.Groups)
+                        if (selectedTab != ContactBookTab.Groups) {
+                            onTabSelected(ContactBookTab.Groups)
+                        }
                     }
                     TabChip("전체", selectedTab == ContactBookTab.Contacts) {
-                        selectedTab = ContactBookTab.Contacts
-                        onTabSelected(ContactBookTab.Contacts)
+                        if (selectedTab != ContactBookTab.Contacts) {
+                            onTabSelected(ContactBookTab.Contacts)
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Task Description
  ### 프롬프트 예시 추가
  - 문체 스타일 예시: 존댓말, 직설적, 결론우선, 격식적, 친근함, 신중함
  - 형식 가이드 예시: 3~5문장, 핵심키워드, 구체적일정, 인사말최소
  - 사용자가 예시를 클릭하면 백엔드 API를 통해 프롬프트 옵션으로 추가됨

  ### 그룹 멤버 관리 기능 구현
  - 그룹 생성 시 멤버를 선택할 수 있는 다이얼로그 추가
  - 체크박스 방식의 멀티 셀렉트 UI 구현
  - 그룹 생성 후 선택된 연락처들의 group_id를 PATCH API로 업데이트
  - ContactApiService에 PATCH 엔드포인트 추가
  - AddGroupViewModel에서 멤버 저장 로직 구현

  ### 버그 수정
  - GroupResponse의 contacts 필드를 nullable로 변경하여 NullPointerException 해결
  - Contact와 Group 간 순환 참조 문제 해결 (group 필드를 null로 설정)
  - 연락처 목록 파싱 실패 문제 해결을 위한 상세 로깅 추가
  - 메일 작성 화면의 기본 내용 제거

  ## Motivation
  - 데모 영상 촬영을 위해 사용자 경험 개선 및 주요 기능 완성 필요
  - 프롬프트 예시를 통해 사용자가 AI 메일 작성 기능을 쉽게 활용할 수 있도록 개선
  - 그룹 생성 시 멤버를 바로 추가할 수 있어 사용자 편의성 향상
  - 백엔드 API 응답 형식과 프론트엔드 모델 간 불일치로 인한 파싱 오류 해결
  - 순환 참조로 인한 무한 루프 방지 및 앱 안정성 향상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 생성 시 연락처를 직접 선택하여 멤버로 추가할 수 있습니다.
  * AI 프롬프팅에 미리 준비된 예제 옵션을 빠르게 추가할 수 있습니다.

* **버그 수정**
  * 메일 작성 화면의 불필요한 기본 콘텐츠 자동 채우기를 제거했습니다.
  * 탭 선택 상태 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->