### PR TITLE
[P1] chore: set loglevel to debug for logging

### DIFF
--- a/backend/docker-compose_dev.yml
+++ b/backend/docker-compose_dev.yml
@@ -25,6 +25,7 @@ services:
     restart: unless-stopped
     ports:
       - "6379:6379"
+    command: redis-server --loglevel debug
  
   nginx:
     image: nginx:1.27-alpine


### PR DESCRIPTION
## Task ID
P1

## Task Description
- Redis의 로깅레벨을 DEBUG모드로 조정하면 publish 메세지를 모두 확인할 수 있습니다.

## Motivation
- 백엔드 - GPU 서버 간 Redis 통신을 확인하기 위해 Redis 의 로깅레벨 조정이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Redis 서버 로그 레벨이 디버그 모드로 설정되어 더 자세한 로깅이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->