### PR TITLE
[A6] 메일 목록 조회 API 개선 및 since_date 쿼리 추가

### DIFF
--- a/backend/apps/mail/serializers.py
+++ b/backend/apps/mail/serializers.py
@@ -11,6 +11,7 @@ class EmailListSerializer(serializers.Serializer):
     snippet = serializers.CharField()
     date = serializers.DateTimeField(allow_null=True)
     date_raw = serializers.CharField()
+    body = serializers.CharField()
     is_unread = serializers.BooleanField()
     label_ids = serializers.ListField(child=serializers.CharField())
 
@@ -94,6 +95,10 @@ class EmailListQuerySerializer(serializers.Serializer):
         required=False,
         allow_blank=True,
         help_text='Comma-separated labels (e.g., "INBOX,UNREAD"). Default: "INBOX"',
+    )
+    since_date = serializers.DateTimeField(
+        required=False,
+        help_text=("ISO8601 timestamp of the newest email the client already has, " "e.g. 2025-10-31T19:14:08+09:00. "),
     )
 
 

--- a/backend/apps/mail/utils.py
+++ b/backend/apps/mail/utils.py
@@ -1,5 +1,6 @@
 import html
 import re
+from datetime import datetime
 
 
 def html_to_text(html_str: str) -> str:
@@ -12,3 +13,40 @@ def html_to_text(html_str: str) -> str:
 def text_to_html(text_str: str) -> str:
     esc = html.escape(text_str)
     return esc.replace("\n", "<br>")
+
+
+def compare_iso_datetimes(s1, s2) -> int:
+    """
+    Compare two ISO8601 datetime strings.
+
+    Args:
+        s1, s2: datetime.datetime or str
+            - e.g. "2025-10-31T20:24:02+09:00"
+            - or datetime(2025, 10, 31, 20, 24, 2, tzinfo=timezone(timedelta(hours=9)))
+
+    Returns:
+        int:
+            -1 if s1 < s2
+             0 if s1 == s2
+             1 if s1 > s2
+    """
+
+    def to_datetime(val):
+        if isinstance(val, datetime):
+            return val
+        elif isinstance(val, str):
+            return datetime.fromisoformat(val.replace(" ", "T"))
+        else:
+            raise TypeError("Unsupported type")
+
+    d1 = to_datetime(s1)
+    d2 = to_datetime(s2)
+
+    if d1.tzinfo is None or d2.tzinfo is None:
+        raise ValueError("Both datetimes must include timezone information")
+
+    if d1 > d2:
+        return 1
+    elif d1 < d2:
+        return -1
+    return 0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ google-auth-oauthlib = "^1.2.1"
 google-auth-httplib2 = "^0.2.0"
 google-api-python-client = "^2.161.0"
 requests = "^2.32.5"
-channels = "^4.1" 
+channels = "^4.1"
 channels-redis = "^4.2"
 redis = {extras = ["asyncio"], version = "^5.0"}
 jinja2 = "^3.1.6"
@@ -46,10 +46,10 @@ black = "^25.9.0"
 
 [tool.black]
 line-length = 150
-target-version = ["py313"]
+target-version = ["py312"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 150
 select = [
   "E",   # pycodestyle errors


### PR DESCRIPTION
## Task ID
A6
## Task Description
- 기존 메일 목록 조회 API에 since_date 쿼리를 추가했습니다. 클라이언트에 저장된 가장 최신 메시지의 date 값(문자열)을 쿼리에 넣으면 그 시점 이후에 새로 발생한 모든 메일을 불러올 수 있습니다.(이때 max_results는 무시됩니다.
- 기존 메일 목록 조회 API 응답 속도를 크게 개선했습니다.
- 기존 방식은 메시지 id 리스트를 불러온 후 동기적으로 각 id에 대한 조회 API를 요청하는 구조였는데 이를 비동기 배치 처리를 하여 개선했습니다.
- 메시지 20개 기준 응답이 8초에서 1.35초로 줄었고 메시지 30개 기준 12.31초에서 1.6초로 응답 시간이 감소했습니다.
- 이제 메일 목록 응답에 body가 추가되었습니다

## Motivation
- 기존 API에 개선이 필요하다고 느낌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 날짜 기반 이메일 필터링 기능 추가 (특정 시간 이후의 이메일 조회 가능)
  * 이메일 목록에 본문 콘텐츠 포함
  * 최신 이메일만 빠르게 동기화하는 증분 새로고침 기능

* **성능 개선**
  * 일괄 메시지 검색으로 이메일 로딩 속도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->