### PR TITLE
[A4]메일 생성 with 타임스탬프 

### DIFF
--- a/backend/apps/ai/urls.py
+++ b/backend/apps/ai/urls.py
@@ -6,12 +6,18 @@ from .views import (
     EmailPromptPreviewView,
     MailGenerateAnalysisTestView,
     MailGenerateStreamView,
+    MailGenerateStreamWithTimestampView,
     MailGenerateWithPlanStreamView,
     ReplyOptionsStreamView,
 )
 
 urlpatterns = [
     path("mail/generate/stream/", MailGenerateStreamView.as_view(), name="mail-generate-stream"),
+    path(
+        "mail/generate-with-timestamp/stream/",
+        MailGenerateStreamWithTimestampView.as_view(),
+        name="mail-generate-stream-with-timestamp",
+    ),
     path("mail/generate-with-plan/stream/", MailGenerateWithPlanStreamView.as_view(), name="mail-generate-with-plan-stream"),
     path("mail/reply/stream/", ReplyOptionsStreamView.as_view(), name="mail-reply-stream"),
     path("mail/prompts/preview/", EmailPromptPreviewView.as_view()),

--- a/backend/apps/ai/views.py
+++ b/backend/apps/ai/views.py
@@ -22,7 +22,12 @@ from .serializers import (
     ReplyGenerateRequest,
 )
 from .services.attachment_analysis import analyze_gmail_attachment, analyze_uploaded_file
-from .services.mail_generation import debug_mail_generation_analysis, stream_mail_generation, stream_mail_generation_with_plan
+from .services.mail_generation import (
+    debug_mail_generation_analysis,
+    stream_mail_generation,
+    stream_mail_generation_with_plan,
+    stream_mail_generation_with_timestamp,
+)
 from .services.prompt_preview import generate_prompt_preview
 from .services.reply import stream_reply_options_llm
 
@@ -124,6 +129,85 @@ class MailGenerateStreamView(AuthRequiredMixin, generics.GenericAPIView):
         )
 
         resp = StreamingHttpResponse(gen, content_type="text/event-stream; charset=utf-8")
+        resp["Cache-Control"] = "no-cache"
+        resp["X-Accel-Buffering"] = "no"
+        return resp
+
+
+class MailGenerateStreamWithTimestampView(AuthRequiredMixin, generics.GenericAPIView):
+    serializer_class = MailGenerateRequest
+    renderer_classes = [SSERenderer]
+
+    @extend_schema(
+        operation_id="mail_generate_stream_with_timestamp",
+        summary="Generate mail via streaming (SSE) with timing info",
+        description=(
+            "메일을 **SSE**(text/event-stream)로 스트리밍하며, "
+            "각 이벤트에 서버 타임스탬프와 경과 시간을 포함하는 디버깅용 엔드포인트입니다.\n\n"
+            "- `ready`: `{ ts, server_ts, elapsed_ms }`\n"
+            "- `subject`: `{ title, text, server_ts, elapsed_ms }`\n"
+            "- `body.delta`: `{ seq, text, server_ts, elapsed_ms, delta_ms }`\n"
+            "  - `server_ts`: 서버에서 이벤트를 전송한 시각(Epoch ms)\n"
+            "  - `elapsed_ms`: 스트림 시작 이후 서버 기준 경과 시간(ms)\n"
+            "  - `delta_ms`: 이전 `body.delta` 이벤트와의 서버 기준 간격(ms, 첫 chunk에는 없음)\n"
+            "- `error`, `done` 도 동일하게 `server_ts`, `elapsed_ms` 포함"
+        ),
+        request=MailGenerateRequest,
+        responses={
+            200: (OpenApiTypes.STR, "text/event-stream"),
+        },
+        examples=[
+            OpenApiExample(
+                "SSE success stream with timestamp",
+                response_only=True,
+                value=(
+                    # Ready
+                    "event: ready\n"
+                    'data: {"ts":1731234567890, "server_ts":1731234567890, "elapsed_ms":0}\n'
+                    "retry: 5000\n"
+                    "\n"
+                    # Subject
+                    "event: subject\n"
+                    "id: 0\n"
+                    'data: {"title":"Interview Result for Five I\\u0027s",'
+                    ' "text":"Interview Result for Five I\\u0027s\\n\\n",'
+                    ' "server_ts":1731234568890, "elapsed_ms":1000}\n'
+                    "\n"
+                    # Body delta with timing
+                    "event: body.delta\n"
+                    "id: 1\n"
+                    'data: {"seq":0, "text":"Hello, and thank you for applying to Five I\\u0027s. ",'
+                    ' "server_ts":1731234569890, "elapsed_ms":2000, "delta_ms":1000}\n'
+                    "\n"
+                    "event: body.delta\n"
+                    "id: 2\n"
+                    'data: {"seq":1, "text":"After careful consideration, we ... ",'
+                    ' "server_ts":1731234570890, "elapsed_ms":3000, "delta_ms":1000}\n'
+                    "\n"
+                    "event: done\n"
+                    "id: 3\n"
+                    'data: {"reason":"stop", "server_ts":1731234571890, "elapsed_ms":4000}\n'
+                    "\n"
+                ),
+            ),
+        ],
+    )
+    def post(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        gen = stream_mail_generation_with_timestamp(
+            user=request.user,
+            subject=data.get("subject"),
+            body=data.get("body"),
+            to_emails=data.get("to_emails"),
+        )
+
+        resp = StreamingHttpResponse(
+            gen,
+            content_type="text/event-stream; charset=utf-8",
+        )
         resp["Cache-Control"] = "no-cache"
         resp["X-Accel-Buffering"] = "no"
         return resp


### PR DESCRIPTION
## Task ID
A4
## Task Description
- 테스트용 메일 생성 with 타임스탬프 API 추가 

## Motivation
- 안드로이드 SSE 스트리밍 디버깅을 위함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메일 생성 스트리밍에 타이밍 메타데이터 기능 추가: 새로운 API 엔드포인트를 통해 메일 생성 과정의 서버 타임스탬프, 전체 경과 시간, 청크별 처리 시간 등의 상세한 성능 정보가 각 스트리밍 이벤트에 포함되어 제공됩니다. 기존의 입력 검증, 마스킹 처리, 에러 처리 및 종료 로직은 모두 동일하게 유지되며, 이벤트 페이로드에만 타이밍 메타데이터가 새롭게 추가됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->