### PR TITLE
feat: implement mail suggestion API

### DIFF
--- a/backend/apps/ai/services/chains.py
+++ b/backend/apps/ai/services/chains.py
@@ -24,6 +24,8 @@ from apps.ai.services.prompts import (
     REPLY_USER,
     SUBJECT_SYSTEM,
     SUBJECT_USER,
+    SUGGEST_SYSTEM,
+    SUGGEST_USER,
     VALIDATOR_SYSTEM,
     VALIDATOR_USER,
 )
@@ -134,3 +136,15 @@ _attachment_prompt = ChatPromptTemplate.from_messages(
 )
 
 attachment_analysis_chain = _attachment_prompt | _base_model.with_structured_output(AttachmentAnalysisResult)
+
+_suggest_prompt = ChatPromptTemplate.from_messages(
+    [("system", SUGGEST_SYSTEM), ("user", SUGGEST_USER)],
+    template_format="jinja2",
+)
+
+_suggest_model = ChatOpenAI(
+    model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
+    temperature=float(os.getenv("AI_TEMPERATURE", "0.6")),
+)
+
+suggest_chain = _suggest_prompt | _suggest_model | StrOutputParser()

--- a/backend/apps/ai/services/mail_suggestion.py
+++ b/backend/apps/ai/services/mail_suggestion.py
@@ -1,0 +1,46 @@
+from apps.ai.services.chains import suggest_chain
+from apps.ai.services.utils import build_prompt_inputs, collect_prompt_context
+
+
+def suggest_mail_text(
+    user,
+    *,
+    subject: str | None,
+    body: str | None,
+    to_emails: list[str],
+    target: str,
+    cursor: int | None = None,
+) -> str:
+
+    subject = subject or ""
+    body = body or ""
+
+    body_before = body
+    body_after = ""
+    if target == "body":
+        if cursor is not None:
+            cursor = max(0, min(cursor, len(body)))
+            body_before = body[:cursor]
+            body_after = body[cursor:]
+        else:
+            # cursor 없으면 그냥 끝에 이어쓰기
+            body_before = body
+            body_after = ""
+
+    ctx = collect_prompt_context(user, to_emails)
+
+    prompt_inputs = build_prompt_inputs(
+        ctx,
+        extra={
+            "subject": subject,
+            "body": body,
+            "body_before": body_before,
+            "body_after": body_after,
+        },
+    )
+    prompt_inputs["target"] = target
+
+    # 3) LLM 호출 (스트리밍 X, 단일 응답)
+    suggestion: str = suggest_chain.invoke(prompt_inputs)
+
+    return suggestion

--- a/backend/apps/ai/services/prompts.py
+++ b/backend/apps/ai/services/prompts.py
@@ -781,3 +781,85 @@ TEXT:
 {{ text }}
 FILENAME: {{ filename }}
 """.strip()
+
+SUGGEST_SYSTEM = """
+You are a real-time autocomplete assistant that generates the next text the user might type.
+
+General rules:
+- Write in the user's original language ({{ language }}).
+- Output ONLY the continuation text.
+- Generate at most one short sentence or clause.
+- Do not repeat existing text.
+- Do not invent unrelated facts.
+- No explanations or quotes.
+
+Cursor-aware generation:
+- Your output will be inserted between "before" and "after".
+- Ensure a smooth, natural continuation.
+
+Spacing rule (STRICT):
+- If "before" does NOT end with a space, your output MUST start with exactly ONE space.
+- If "before" ends with a space, your output MUST NOT start with a space.
+- This means the first character of your output MUST include the correct spacing decision.
+- No extra leading or trailing spaces.
+
+Examples:
+[Korean]
+before: "안녕하세요 오늘 날씨가"
+→ valid: " 좋네요."
+
+[English]
+before: "The meeting will start"
+→ valid: " soon."
+""".strip()
+
+
+SUGGEST_USER = """
+The user is writing in {{ language }}.
+
+{%- if profile %}
+Use this profile only to match tone and style (do NOT insert the info directly):
+<profile>
+Name: {{ profile.display_name }}
+Info: {{ profile.info }}
+</profile>
+{%- endif %}
+
+Target field to continue: {{ target }}
+
+{%- if target == "body" %}
+
+Text before cursor:
+"{{ body_before }}"
+
+Text after cursor (context only; do NOT copy it):
+"{{ body_after }}"
+
+Instructions:
+- Your output will be inserted here:
+  final = before + your_output + after
+- Produce one short, natural continuation.
+- Ensure your output connects smoothly to both sides.
+- Follow the strict spacing rules:
+  • If before ends with a space → do NOT start with a space.
+  • If before does NOT end with a space → start with EXACTLY ONE space.
+
+{%- else %}
+
+Current subject:
+"{{ subject }}"
+
+Instructions:
+- Provide one short phrase to extend the subject naturally.
+- Follow the same spacing rules.
+
+{%- endif %}
+
+{%- if prompt_text %}
+User tone/style preference:
+{{ prompt_text }}
+(Use for tone only.)
+{%- endif %}
+
+Return only the continuation text.
+""".strip()

--- a/backend/apps/ai/services/utils.py
+++ b/backend/apps/ai/services/utils.py
@@ -110,7 +110,7 @@ def collect_prompt_context(
         "personal_prompt": None,
         "sender_role": None,
         "recipient_role": None,
-        "language": language,
+        "language": language or "user's original language",
         "fewshots": [],
         "analysis": None,
         "profile": profile,

--- a/backend/apps/ai/urls.py
+++ b/backend/apps/ai/urls.py
@@ -8,6 +8,7 @@ from .views import (
     MailGenerateStreamTestView,
     MailGenerateStreamView,
     MailGenerateWithPlanStreamView,
+    MailSuggestView,
     ReplyOptionsStreamView,
 )
 
@@ -28,4 +29,5 @@ urlpatterns = [
         name="mail-attachment-analyze-upload",
     ),
     path("mail/generate/test/", MailGenerateAnalysisTestView.as_view(), name="mail-generate-test"),
+    path("mail/suggest/", MailSuggestView.as_view(), name="mail-suggest"),
 ]


### PR DESCRIPTION
## Task Description
- UAT 끝난 이후에 머지하면 될 것 같습니다.
- 요청과 응답 format이 수정됐습니다.
- 기존 로컬 LLM에서 GPT API로 수정
- 웹소켓 방식에서 일단적인 REST API로 수정
- 프론트에서 디바운스로 요청하도록 구현 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 메일 작성 중 제목과 본문에 대한 AI 기반 자동 완성 텍스트 제안 기능 추가
* 본문 내 특정 커서 위치를 기반으로 한 정확한 텍스트 제안 제공
* 수신자 이메일 주소 정보를 활용하여 개인화된 제안 생성
* 인증된 사용자를 위한 새로운 제안 API 엔드포인트 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->